### PR TITLE
Rename WOCKY_NS_STREAM_MANAGEMENT 

### DIFF
--- a/wocky/wocky-connector.c
+++ b/wocky/wocky-connector.c
@@ -1297,7 +1297,7 @@ xmpp_features_cb (GObject *source,
   can_bind =
     wocky_node_get_child_ns (node, "bind", WOCKY_XMPP_NS_BIND) != NULL;
   can_sm =
-    wocky_node_get_child_ns (node, "sm", WOCKY_NS_STREAM_MANAGEMENT) != NULL;
+    wocky_node_get_child_ns (node, "sm", WOCKY_XMPP_NS_STREAM_MANAGEMENT) != NULL;
 
 
   if (can_sm)
@@ -1926,7 +1926,7 @@ static void sm_enable (WockyConnector *self)
 {
 
   WockyConnectorPrivate *priv = self->priv;
-  WockyStanza *enable = wocky_stanza_new ("enable", WOCKY_NS_STREAM_MANAGEMENT);
+  WockyStanza *enable = wocky_stanza_new ("enable", WOCKY_XMPP_NS_STREAM_MANAGEMENT);
 
   DEBUG ("sending sm enable stanza");
   wocky_xmpp_connection_send_stanza_async (priv->conn, enable, priv->cancellable,
@@ -2112,7 +2112,7 @@ iq_bind_resource_recv_cb (GObject *source,
 
         node = wocky_stanza_get_top_node (priv->features);
 
-        if (wocky_node_get_child_ns (node, "sm", WOCKY_NS_STREAM_MANAGEMENT) != NULL)
+        if (wocky_node_get_child_ns (node, "sm", WOCKY_XMPP_NS_STREAM_MANAGEMENT) != NULL)
           sm_enable (self);
         else
           establish_session (self);

--- a/wocky/wocky-connector.c
+++ b/wocky/wocky-connector.c
@@ -2115,7 +2115,7 @@ iq_bind_resource_recv_cb (GObject *source,
         if (wocky_node_get_child_ns (node, "sm", WOCKY_NS_STREAM_MANAGEMENT) != NULL)
           sm_enable (self);
         else
-                establish_session (self);
+          establish_session (self);
 
 
         break;

--- a/wocky/wocky-namespaces.h
+++ b/wocky/wocky-namespaces.h
@@ -211,6 +211,6 @@
 #define WOCKY_NS_VCARD_TEMP_UPDATE    "vcard-temp:x:update"
 
 /* XEP-0198 (Stream Management) */
-#define WOCKY_NS_STREAM_MANAGEMENT "urn:xmpp:sm:3"
+#define WOCKY_XMPP_NS_STREAM_MANAGEMENT "urn:xmpp:sm:3"
 
 #endif /* #ifndef __WOCKY_NAMESPACES_H__ */

--- a/wocky/wocky-sm.c
+++ b/wocky/wocky-sm.c
@@ -208,7 +208,7 @@ wocky_sm_new (WockyC2SPorter *porter)
  */
 void wocky_sm_send_a (WockyPorter* porter, uint recv_count)
 {
-  WockyStanza *stanza_a = wocky_stanza_new ("a", WOCKY_NS_STREAM_MANAGEMENT);
+  WockyStanza *stanza_a = wocky_stanza_new ("a", WOCKY_XMPP_NS_STREAM_MANAGEMENT);
 
   if (stanza_a != NULL)
   {
@@ -232,7 +232,7 @@ void wocky_sm_send_a (WockyPorter* porter, uint recv_count)
  */
 void wocky_sm_send_r (WockyPorter* porter, uint count_sent)
 {
-  WockyStanza *stanza_r = wocky_stanza_new ("r", WOCKY_NS_STREAM_MANAGEMENT);
+  WockyStanza *stanza_r = wocky_stanza_new ("r", WOCKY_XMPP_NS_STREAM_MANAGEMENT);
 
   if (stanza_r != NULL)
   {

--- a/wocky/wocky-stanza.c
+++ b/wocky/wocky-stanza.c
@@ -80,11 +80,11 @@ static StanzaTypeName type_names[NUM_WOCKY_STANZA_TYPE] =
     { WOCKY_STANZA_TYPE_STREAM_ERROR,    "error",
         WOCKY_XMPP_NS_STREAM },
     { WOCKY_STANZA_TYPE_ENABLE,          "enable",
-        WOCKY_NS_STREAM_MANAGEMENT },
+        WOCKY_XMPP_NS_STREAM_MANAGEMENT },
     { WOCKY_STANZA_TYPE_SM_R,            "r",
-        WOCKY_NS_STREAM_MANAGEMENT },
+        WOCKY_XMPP_NS_STREAM_MANAGEMENT },
       { WOCKY_STANZA_TYPE_SM_A,          "a",
-        WOCKY_NS_STREAM_MANAGEMENT },
+        WOCKY_XMPP_NS_STREAM_MANAGEMENT },
     { WOCKY_STANZA_TYPE_UNKNOWN,         NULL,        NULL },
 };
 


### PR DESCRIPTION
While writing the unit tests I needed to rename your WOCKY_NS_STREAM_MANAGEMENT macro.

Here's the macro:
https://github.com/detrout/wocky/blob/XEP-0198_Stream_Management/tests/wocky-test-connector-server.c#L233
Which assumes the NS macro names are of the format WOCKY_XMPP_NS_foo

Also I missed a whitespace cleanup line.
